### PR TITLE
Add admin pages for actors/users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ FEDERATION_DOMAIN=localhost:3000
 FEDERATION_PROTOCOL=http
 
 # ======================
+# Frontend Configuration
+# ======================
+FRONTEND_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000
+ADMIN_URL=http://localhost:3004
+
+# ======================
 # Redis Configuration
 # ======================
 REDIS_URL=redis://redis:6379

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "yarn workspace @cosmoslide/backend test:watch",
     "lint": "yarn workspaces run lint",
     "format": "prettier --write \"packages/**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "create-user": "yarn workspace @cosmoslide/backend create-user"
+    "create-user": "yarn workspace @cosmoslide/backend create-user",
+    "grant-admin": "yarn workspace @cosmoslide/backend grant-admin"
   },
   "devDependencies": {
     "concurrently": "^8.2.0",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -9,8 +9,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.9",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.1.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -1,26 +1,38 @@
-function App() {
-  return (
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      minHeight: '100vh',
-      fontFamily: 'system-ui, -apple-system, sans-serif',
-      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-      color: 'white',
-    }}>
-      <h1 style={{ fontSize: '3rem', marginBottom: '1rem' }}>
-        Hello World from Admin
-      </h1>
-      <p style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>
-        Cosmoslide Admin Panel
-      </p>
-      <p style={{ fontSize: '1rem', opacity: 0.9 }}>
-        🚀 Powered by Vite + React
-      </p>
-    </div>
-  )
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import Login from './pages/Login';
+import Users from './pages/Users';
+import Actors from './pages/Actors';
+
+function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const token = localStorage.getItem('token');
+  return token ? <>{children}</> : <Navigate to="/login" />;
 }
 
-export default App
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/users"
+          element={
+            <ProtectedRoute>
+              <Users />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/actors"
+          element={
+            <ProtectedRoute>
+              <Actors />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/" element={<Navigate to="/users" />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/packages/admin/src/components/CreateUserModal.tsx
+++ b/packages/admin/src/components/CreateUserModal.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react';
+import { adminAPI } from '../lib/api';
+
+interface CreateUserModalProps {
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function CreateUserModal({ onClose, onSuccess }: CreateUserModalProps) {
+  const [formData, setFormData] = useState({
+    email: '',
+    username: '',
+    displayName: '',
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError('');
+
+    try {
+      await adminAPI.createUser(formData);
+      onSuccess();
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Failed to create user');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: 'rgba(0,0,0,0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+    }}>
+      <div style={{
+        background: 'white',
+        padding: '2rem',
+        borderRadius: '12px',
+        width: '100%',
+        maxWidth: '500px',
+        maxHeight: '90vh',
+        overflow: 'auto',
+      }}>
+        <h2 style={{ marginBottom: '1.5rem', fontSize: '1.5rem', fontWeight: 'bold' }}>
+          Create New User
+        </h2>
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '1rem' }}>
+            <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: '500' }}>
+              Email *
+            </label>
+            <input
+              type="email"
+              value={formData.email}
+              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+              required
+              style={{
+                width: '100%',
+                padding: '0.75rem',
+                border: '1px solid #ddd',
+                borderRadius: '6px',
+              }}
+            />
+          </div>
+
+          <div style={{ marginBottom: '1rem' }}>
+            <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: '500' }}>
+              Username *
+            </label>
+            <input
+              type="text"
+              value={formData.username}
+              onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+              required
+              style={{
+                width: '100%',
+                padding: '0.75rem',
+                border: '1px solid #ddd',
+                borderRadius: '6px',
+              }}
+            />
+          </div>
+
+          <div style={{ marginBottom: '1.5rem' }}>
+            <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: '500' }}>
+              Display Name
+            </label>
+            <input
+              type="text"
+              value={formData.displayName}
+              onChange={(e) => setFormData({ ...formData, displayName: e.target.value })}
+              style={{
+                width: '100%',
+                padding: '0.75rem',
+                border: '1px solid #ddd',
+                borderRadius: '6px',
+              }}
+            />
+          </div>
+
+          {error && (
+            <div style={{
+              marginBottom: '1rem',
+              padding: '0.75rem',
+              background: '#f8d7da',
+              color: '#721c24',
+              borderRadius: '6px',
+            }}>
+              {error}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isLoading}
+              style={{
+                padding: '0.75rem 1.5rem',
+                background: '#e5e7eb',
+                border: 'none',
+                borderRadius: '6px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading}
+              style={{
+                padding: '0.75rem 1.5rem',
+                background: '#667eea',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                opacity: isLoading ? 0.7 : 1,
+              }}
+            >
+              {isLoading ? 'Creating...' : 'Create User'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/Layout.tsx
+++ b/packages/admin/src/components/Layout.tsx
@@ -1,0 +1,81 @@
+import { Link, useNavigate } from 'react-router-dom';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    navigate('/login');
+  };
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh', background: '#f3f4f6' }}>
+      {/* Sidebar */}
+      <div style={{
+        width: '250px',
+        background: 'linear-gradient(180deg, #667eea 0%, #764ba2 100%)',
+        color: 'white',
+        padding: '1.5rem',
+      }}>
+        <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '2rem' }}>
+          Cosmoslide Admin
+        </h2>
+
+        <nav style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <Link
+            to="/users"
+            style={{
+              padding: '0.75rem 1rem',
+              borderRadius: '6px',
+              textDecoration: 'none',
+              color: 'white',
+              background: window.location.pathname === '/users' ? 'rgba(255,255,255,0.2)' : 'transparent',
+            }}
+          >
+            👥 Users
+          </Link>
+          <Link
+            to="/actors"
+            style={{
+              padding: '0.75rem 1rem',
+              borderRadius: '6px',
+              textDecoration: 'none',
+              color: 'white',
+              background: window.location.pathname === '/actors' ? 'rgba(255,255,255,0.2)' : 'transparent',
+            }}
+          >
+            🎭 Actors
+          </Link>
+        </nav>
+
+        <button
+          onClick={handleLogout}
+          style={{
+            position: 'absolute',
+            bottom: '1.5rem',
+            left: '1.5rem',
+            right: '1.5rem',
+            width: 'calc(100% - 3rem)',
+            padding: '0.75rem',
+            background: 'rgba(255,255,255,0.2)',
+            color: 'white',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer',
+          }}
+        >
+          🚪 Logout
+        </button>
+      </div>
+
+      {/* Main content */}
+      <div style={{ flex: 1, padding: '2rem' }}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/lib/api.ts
+++ b/packages/admin/src/lib/api.ts
@@ -1,0 +1,61 @@
+import axios from "axios";
+
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+export const api = axios.create({
+  baseURL: API_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// Add token to requests if available
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// Handle 401 errors
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem("token");
+      window.location.href = "/login";
+    }
+    return Promise.reject(error);
+  },
+);
+
+// Auth API
+export const authAPI = {
+  requestMagicLink: (email: string) => api.post("/admin/auth/magic-link", { email }),
+
+  verifyMagicLink: (token: string) => api.post(`/auth/verify?token=${token}`),
+
+  getMe: () => api.get("/auth/me"),
+};
+
+// Admin API
+export const adminAPI = {
+  getUsers: (page = 1, limit = 20) =>
+    api.get(`/admin/users?page=${page}&limit=${limit}`),
+
+  createUser: (
+    data: { email: string; username: string; displayName?: string },
+  ) => api.post("/admin/users", data),
+
+  toggleAdminStatus: (userId: string, isAdmin: boolean) =>
+    api.patch(`/admin/users/${userId}/admin`, { isAdmin }),
+
+  getActors: (page = 1, limit = 20, isLocal?: boolean) => {
+    let url = `/admin/actors?page=${page}&limit=${limit}`;
+    if (isLocal !== undefined) {
+      url += `&isLocal=${isLocal}`;
+    }
+    return api.get(url);
+  },
+};

--- a/packages/admin/src/pages/Actors.tsx
+++ b/packages/admin/src/pages/Actors.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from 'react';
+import { adminAPI } from '../lib/api';
+import Layout from '../components/Layout';
+
+interface Actor {
+  id: string;
+  preferredUsername: string;
+  name: string;
+  domain: string;
+  isLocal: boolean;
+  userId: string | null;
+  createdAt: string;
+  user?: {
+    id: string;
+    username: string;
+    email: string;
+  };
+}
+
+export default function Actors() {
+  const [actors, setActors] = useState<Actor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [filter, setFilter] = useState<boolean | undefined>(undefined);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    fetchActors();
+  }, [page, filter]);
+
+  const fetchActors = async () => {
+    try {
+      const response = await adminAPI.getActors(page, 20, filter);
+      setActors(response.data.data);
+      setTotal(response.data.meta.total);
+    } catch (error) {
+      console.error('Failed to fetch actors:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) return <Layout><div>Loading...</div></Layout>;
+
+  return (
+    <Layout>
+      <div style={{ marginBottom: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1 style={{ fontSize: '1.875rem', fontWeight: 'bold' }}>Actors</h1>
+
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button
+            onClick={() => setFilter(undefined)}
+            style={{
+              padding: '0.5rem 1rem',
+              background: filter === undefined ? '#667eea' : '#e5e7eb',
+              color: filter === undefined ? 'white' : 'black',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+            }}
+          >
+            All
+          </button>
+          <button
+            onClick={() => setFilter(true)}
+            style={{
+              padding: '0.5rem 1rem',
+              background: filter === true ? '#667eea' : '#e5e7eb',
+              color: filter === true ? 'white' : 'black',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+            }}
+          >
+            Local
+          </button>
+          <button
+            onClick={() => setFilter(false)}
+            style={{
+              padding: '0.5rem 1rem',
+              background: filter === false ? '#667eea' : '#e5e7eb',
+              color: filter === false ? 'white' : 'black',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+            }}
+          >
+            Remote
+          </button>
+        </div>
+      </div>
+
+      <div style={{ background: 'white', borderRadius: '8px', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead style={{ background: '#f9fafb' }}>
+            <tr>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Username</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Display Name</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Domain</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Type</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Local User</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {actors.map((actor) => (
+              <tr key={actor.id} style={{ borderTop: '1px solid #e5e7eb' }}>
+                <td style={{ padding: '0.75rem' }}>{actor.preferredUsername}</td>
+                <td style={{ padding: '0.75rem' }}>{actor.name || '-'}</td>
+                <td style={{ padding: '0.75rem' }}>{actor.domain}</td>
+                <td style={{ padding: '0.75rem' }}>
+                  <span style={{
+                    padding: '0.25rem 0.5rem',
+                    background: actor.isLocal ? '#d4edda' : '#f8d7da',
+                    color: actor.isLocal ? '#155724' : '#721c24',
+                    borderRadius: '4px',
+                    fontSize: '0.875rem',
+                  }}>
+                    {actor.isLocal ? 'Local' : 'Remote'}
+                  </span>
+                </td>
+                <td style={{ padding: '0.75rem' }}>
+                  {actor.user ? (
+                    <span style={{ color: '#667eea', fontWeight: '500' }}>
+                      {actor.user.username}
+                    </span>
+                  ) : (
+                    '-'
+                  )}
+                </td>
+                <td style={{ padding: '0.75rem', fontSize: '0.875rem' }}>
+                  {new Date(actor.createdAt).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+        <button
+          onClick={() => setPage(p => Math.max(1, p - 1))}
+          disabled={page === 1}
+          style={{
+            padding: '0.5rem 1rem',
+            background: page === 1 ? '#ccc' : '#667eea',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: page === 1 ? 'not-allowed' : 'pointer',
+          }}
+        >
+          Previous
+        </button>
+        <span style={{ padding: '0.5rem 1rem' }}>
+          Page {page} ({total} total actors)
+        </span>
+        <button
+          onClick={() => setPage(p => p + 1)}
+          disabled={actors.length < 20}
+          style={{
+            padding: '0.5rem 1rem',
+            background: actors.length < 20 ? '#ccc' : '#667eea',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: actors.length < 20 ? 'not-allowed' : 'pointer',
+          }}
+        >
+          Next
+        </button>
+      </div>
+    </Layout>
+  );
+}

--- a/packages/admin/src/pages/Login.tsx
+++ b/packages/admin/src/pages/Login.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { authAPI } from '../lib/api';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    if (token) {
+      verifyToken(token);
+    }
+  }, [searchParams]);
+
+  const verifyToken = async (token: string) => {
+    setIsLoading(true);
+    try {
+      // Step 1: Verify magic link and get token
+      const response = await authAPI.verifyMagicLink(token);
+      const accessToken = response.data.access_token;
+
+      // Step 2: Store token temporarily
+      localStorage.setItem('token', accessToken);
+
+      // Step 3: Get user info to check admin status
+      const userResponse = await authAPI.getMe();
+      const user = userResponse.data;
+
+      // Step 4: Check if user has admin privileges
+      if (!user.isAdmin) {
+        // Remove token and show error
+        localStorage.removeItem('token');
+        setMessage('Access denied. Admin privileges required.');
+        setIsLoading(false);
+        return;
+      }
+
+      // Step 5: User is admin, redirect to users page
+      navigate('/users');
+    } catch (error: any) {
+      localStorage.removeItem('token');
+      setMessage(error.response?.data?.message || 'Invalid or expired magic link');
+      setIsLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setMessage('');
+
+    try {
+      await authAPI.requestMagicLink(email);
+      setMessage('Magic link sent! Check your email.');
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message;
+      if (errorMessage?.includes('Admin privileges required')) {
+        setMessage('This email is not registered as an admin account.');
+      } else if (errorMessage?.includes('User not found')) {
+        setMessage('No account found with this email.');
+      } else {
+        setMessage(errorMessage || 'Failed to send magic link');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+    }}>
+      <div style={{
+        background: 'white',
+        padding: '2rem',
+        borderRadius: '12px',
+        boxShadow: '0 10px 25px rgba(0,0,0,0.1)',
+        width: '100%',
+        maxWidth: '400px',
+      }}>
+        <h1 style={{ marginBottom: '1.5rem', textAlign: 'center' }}>
+          Cosmoslide Admin
+        </h1>
+
+        {isLoading && searchParams.get('token') ? (
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <div style={{ marginBottom: '1rem' }}>Verifying...</div>
+            <div style={{
+              width: '40px',
+              height: '40px',
+              border: '4px solid #f3f3f3',
+              borderTop: '4px solid #667eea',
+              borderRadius: '50%',
+              animation: 'spin 1s linear infinite',
+              margin: '0 auto'
+            }}></div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: '1rem' }}>
+              <label htmlFor="email" style={{ display: 'block', marginBottom: '0.5rem' }}>
+                Admin Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                disabled={isLoading}
+                placeholder="admin@example.com"
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '6px',
+                  fontSize: '1rem',
+                }}
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={isLoading}
+              style={{
+                width: '100%',
+                padding: '0.75rem',
+                background: '#667eea',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                fontSize: '1rem',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                opacity: isLoading ? 0.7 : 1,
+              }}
+            >
+              {isLoading ? 'Sending...' : 'Send Magic Link'}
+            </button>
+          </form>
+        )}
+
+        {message && (
+          <div style={{
+            marginTop: '1rem',
+            padding: '0.75rem',
+            background: message.includes('sent') ? '#d4edda' : '#f8d7da',
+            color: message.includes('sent') ? '#155724' : '#721c24',
+            borderRadius: '6px',
+            textAlign: 'center',
+            fontSize: '0.875rem',
+          }}>
+            {message}
+          </div>
+        )}
+
+        <style>
+          {`
+            @keyframes spin {
+              0% { transform: rotate(0deg); }
+              100% { transform: rotate(360deg); }
+            }
+          `}
+        </style>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/pages/Users.tsx
+++ b/packages/admin/src/pages/Users.tsx
@@ -1,0 +1,180 @@
+import { useState, useEffect } from 'react';
+import { adminAPI } from '../lib/api';
+import Layout from '../components/Layout';
+import CreateUserModal from '../components/CreateUserModal';
+
+interface User {
+  id: string;
+  username: string;
+  email: string;
+  displayName: string;
+  isAdmin: boolean;
+  createdAt: string;
+  actor?: {
+    id: string;
+    actorId: string;
+    isLocal: boolean;
+  };
+}
+
+export default function Users() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [page]);
+
+  const fetchUsers = async () => {
+    try {
+      const response = await adminAPI.getUsers(page, 20);
+      setUsers(response.data.data);
+      setTotal(response.data.meta.total);
+    } catch (error) {
+      console.error('Failed to fetch users:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleAdmin = async (userId: string, currentStatus: boolean) => {
+    if (!confirm(`${currentStatus ? 'Revoke' : 'Grant'} admin access?`)) return;
+
+    try {
+      await adminAPI.toggleAdminStatus(userId, !currentStatus);
+      fetchUsers();
+    } catch (error) {
+      alert('Failed to update admin status');
+    }
+  };
+
+  if (loading) return <Layout><div>Loading...</div></Layout>;
+
+  return (
+    <Layout>
+      <div style={{ marginBottom: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1 style={{ fontSize: '1.875rem', fontWeight: 'bold' }}>Users</h1>
+        <button
+          onClick={() => setShowModal(true)}
+          style={{
+            padding: '0.5rem 1rem',
+            background: '#667eea',
+            color: 'white',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer',
+          }}
+        >
+          Create User
+        </button>
+      </div>
+
+      <div style={{ background: 'white', borderRadius: '8px', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead style={{ background: '#f9fafb' }}>
+            <tr>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Username</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Email</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Display Name</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Actor</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Admin</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Created</th>
+              <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: '600' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user) => (
+              <tr key={user.id} style={{ borderTop: '1px solid #e5e7eb' }}>
+                <td style={{ padding: '0.75rem' }}>{user.username}</td>
+                <td style={{ padding: '0.75rem' }}>{user.email}</td>
+                <td style={{ padding: '0.75rem' }}>{user.displayName}</td>
+                <td style={{ padding: '0.75rem' }}>
+                  {user.actor && (
+                    <span style={{
+                      padding: '0.25rem 0.5rem',
+                      background: user.actor.isLocal ? '#d4edda' : '#f8d7da',
+                      color: user.actor.isLocal ? '#155724' : '#721c24',
+                      borderRadius: '4px',
+                      fontSize: '0.875rem',
+                    }}>
+                      {user.actor.isLocal ? 'Local' : 'Remote'}
+                    </span>
+                  )}
+                </td>
+                <td style={{ padding: '0.75rem' }}>
+                  {user.isAdmin ? '✅' : '❌'}
+                </td>
+                <td style={{ padding: '0.75rem', fontSize: '0.875rem' }}>
+                  {new Date(user.createdAt).toLocaleDateString()}
+                </td>
+                <td style={{ padding: '0.75rem' }}>
+                  <button
+                    onClick={() => toggleAdmin(user.id, user.isAdmin)}
+                    style={{
+                      padding: '0.25rem 0.75rem',
+                      background: user.isAdmin ? '#f44336' : '#4caf50',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontSize: '0.875rem',
+                    }}
+                  >
+                    {user.isAdmin ? 'Revoke Admin' : 'Grant Admin'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+        <button
+          onClick={() => setPage(p => Math.max(1, p - 1))}
+          disabled={page === 1}
+          style={{
+            padding: '0.5rem 1rem',
+            background: page === 1 ? '#ccc' : '#667eea',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: page === 1 ? 'not-allowed' : 'pointer',
+          }}
+        >
+          Previous
+        </button>
+        <span style={{ padding: '0.5rem 1rem' }}>
+          Page {page} ({total} total users)
+        </span>
+        <button
+          onClick={() => setPage(p => p + 1)}
+          disabled={users.length < 20}
+          style={{
+            padding: '0.5rem 1rem',
+            background: users.length < 20 ? '#ccc' : '#667eea',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: users.length < 20 ? 'not-allowed' : 'pointer',
+          }}
+        >
+          Next
+        </button>
+      </div>
+
+      {showModal && (
+        <CreateUserModal
+          onClose={() => setShowModal(false)}
+          onSuccess={() => {
+            setShowModal(false);
+            fetchUsers();
+          }}
+        />
+      )}
+    </Layout>
+  );
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,7 +17,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "create-user": "ts-node -r tsconfig-paths/register src/scripts/create-user.ts"
+    "create-user": "ts-node -r tsconfig-paths/register src/scripts/create-user.ts",
+    "grant-admin": "ts-node -r tsconfig-paths/register src/scripts/grant-admin.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { MailModule } from './modules/mail/mail.module';
 import { MicrobloggingModule } from './modules/microblogging/microblogging.module';
 import { UploadModule } from './modules/upload/upload.module';
 import { PresentationModule } from './modules/presentation/presentation.module';
+import { AdminModule } from './modules/admin/admin.module';
 import {
   InProcessMessageQueue,
   MemoryKvStore,
@@ -51,6 +52,7 @@ const federationOrigin =
     MicrobloggingModule,
     UploadModule,
     PresentationModule,
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [AppService],
@@ -72,7 +74,7 @@ export class AppModule implements NestModule {
       },
     );
 
-    // Apply raw middleware with increased limit to all routes except upload
+    // Apply raw middleware with increased limit to all routes except upload and admin
     consumer
       .apply(
         express.raw({ type: '*/*', limit: '200mb' }), // 모든 Content-Type을 Buffer로
@@ -83,6 +85,8 @@ export class AppModule implements NestModule {
         { path: 'upload/(.*)', method: RequestMethod.POST },
         { path: 'presentations', method: RequestMethod.POST },
         { path: 'presentations/(.*)', method: RequestMethod.POST },
+        { path: 'admin', method: RequestMethod.ALL },
+        { path: 'admin/(.*)', method: RequestMethod.ALL },
       )
       // NOTE: IMPORTANT
       .forRoutes({ path: '*', method: RequestMethod.ALL });

--- a/packages/backend/src/entities/user.entity.ts
+++ b/packages/backend/src/entities/user.entity.ts
@@ -40,6 +40,9 @@ export class User {
   @Column({ default: false })
   isLocked: boolean;
 
+  @Column({ default: false })
+  isAdmin: boolean;
+
   // Relationship for followers (users who follow this user)
   @OneToMany(() => Follow, (follow) => follow.following)
   followers: Follow[];

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -1,17 +1,15 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { AsyncLocalStorage } from "node:async_hooks";
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
 
-import { configure, getConsoleSink } from '@logtape/logtape';
-import {
-  NestExpressApplication,
-} from '@nestjs/platform-express';
+import { configure, getConsoleSink } from "@logtape/logtape";
+import { NestExpressApplication } from "@nestjs/platform-express";
 
 configure({
   sinks: { console: getConsoleSink() },
   loggers: [
-    { category: 'your-app', sinks: ['console'], lowestLevel: 'debug' },
-    { category: 'fedify', sinks: ['console'], lowestLevel: 'debug' },
+    { category: "cosmoslide", sinks: ["console"], lowestLevel: "debug" },
+    { category: "fedify", sinks: ["console"], lowestLevel: "debug" },
   ],
   contextLocalStorage: new AsyncLocalStorage(),
 });
@@ -22,10 +20,10 @@ async function bootstrap() {
   });
 
   // Configure body parser with larger limits for file uploads
-  const maxBodySize = '200mb';
+  const maxBodySize = "200mb";
   app.use(
-    require('express').json({ limit: maxBodySize }),
-    require('express').urlencoded({ limit: maxBodySize, extended: true }),
+    require("express").json({ limit: maxBodySize }),
+    require("express").urlencoded({ limit: maxBodySize, extended: true }),
   );
 
   // Enable CORS for frontend
@@ -36,8 +34,8 @@ async function bootstrap() {
       "http://localhost:3000",
     ],
     credentials: true,
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization'],
+    methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
   });
 
   // app.set('trust proxy', 1);

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -30,9 +30,10 @@ async function bootstrap() {
 
   // Enable CORS for frontend
   app.enableCors({
-    origin: process.env.FRONTEND_URL || [
-      'http://localhost:3001',
-      'http://localhost:3000',
+    origin: [
+      (process.env.FRONTEND_URL) || "http://localhost:3001",
+      (process.env.ADMIN_URL) || "http://localhost:3004",
+      "http://localhost:3000",
     ],
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],

--- a/packages/backend/src/modules/admin/admin.controller.ts
+++ b/packages/backend/src/modules/admin/admin.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  ParseIntPipe,
+  ParseBoolPipe,
+} from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Public } from '../auth/decorators/public.decorator';
+
+@Controller('admin')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+export class AdminController {
+  constructor(private adminService: AdminService) {}
+
+  // Request admin magic link (public endpoint)
+  @Public()
+  @Post('auth/magic-link')
+  async requestAdminMagicLink(@Body('email') email: string) {
+    await this.adminService.requestAdminMagicLink(email);
+    return { message: 'Magic link sent to your email' };
+  }
+
+  // Get all users with pagination
+  @Get('users')
+  async getAllUsers(
+    @Query('page', new ParseIntPipe({ optional: true })) page?: number,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+  ) {
+    return await this.adminService.getAllUsers(page || 1, limit || 20);
+  }
+
+  // Create a new user
+  @Post('users')
+  async createUser(
+    @Body()
+    createUserDto: {
+      email: string;
+      username: string;
+      displayName?: string;
+    },
+  ) {
+    return await this.adminService.createUser(
+      createUserDto.email,
+      createUserDto.username,
+      createUserDto.displayName,
+    );
+  }
+
+  // Toggle admin status
+  @Patch('users/:id/admin')
+  async toggleAdminStatus(
+    @Param('id') id: string,
+    @Body('isAdmin', ParseBoolPipe) isAdmin: boolean,
+  ) {
+    return await this.adminService.toggleAdminStatus(id, isAdmin);
+  }
+
+  // Get all actors with pagination
+  @Get('actors')
+  async getAllActors(
+    @Query('page', new ParseIntPipe({ optional: true })) page?: number,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+    @Query('isLocal', new ParseBoolPipe({ optional: true })) isLocal?: boolean,
+  ) {
+    return await this.adminService.getAllActors(page || 1, limit || 20, isLocal);
+  }
+}

--- a/packages/backend/src/modules/admin/admin.module.ts
+++ b/packages/backend/src/modules/admin/admin.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { User, Actor, Invitation } from '../../entities';
+import { UserModule } from '../user/user.module';
+import { FederationModule } from '../federation/federation.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User, Actor, Invitation]),
+    UserModule,
+    FederationModule,
+    AuthModule,
+  ],
+  controllers: [AdminController],
+  providers: [AdminService],
+  exports: [AdminService],
+})
+export class AdminModule {}

--- a/packages/backend/src/modules/admin/admin.service.ts
+++ b/packages/backend/src/modules/admin/admin.service.ts
@@ -1,0 +1,187 @@
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User, Actor, KeyPair, Invitation } from '../../entities';
+import { UserService } from '../user/user.service';
+import { ActorSyncService } from '../federation/services/actor-sync.service';
+import { AuthService } from '../auth/auth.service';
+import { randomBytes } from 'crypto';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+
+    @InjectRepository(Actor)
+    private actorRepository: Repository<Actor>,
+
+    @InjectRepository(Invitation)
+    private invitationRepository: Repository<Invitation>,
+
+    private userService: UserService,
+    private actorSyncService: ActorSyncService,
+    private authService: AuthService,
+  ) {}
+
+  // Get all users with pagination and actor relation
+  async getAllUsers(page: number = 1, limit: number = 20) {
+    const [users, total] = await this.userRepository.findAndCount({
+      relations: ['actor'],
+      skip: (page - 1) * limit,
+      take: limit,
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+
+    return {
+      data: users,
+      meta: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  // Get all actors with pagination
+  async getAllActors(page: number = 1, limit: number = 20, isLocal?: boolean) {
+    const queryBuilder = this.actorRepository
+      .createQueryBuilder('actor')
+      .leftJoinAndSelect('actor.user', 'user')
+      .orderBy('actor.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (isLocal !== undefined) {
+      queryBuilder.where('actor.isLocal = :isLocal', { isLocal });
+    }
+
+    const [actors, total] = await queryBuilder.getManyAndCount();
+
+    return {
+      data: actors,
+      meta: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  // Create a new user (same as create-user script)
+  async createUser(email: string, username: string, displayName?: string) {
+    // Check if user already exists
+    const existingUser = await this.userRepository.findOne({
+      where: [{ email }, { username }],
+    });
+
+    if (existingUser) {
+      throw new Error('User with this email or username already exists');
+    }
+
+    // Create user
+    const user = this.userRepository.create({
+      username,
+      email,
+      displayName: displayName || username,
+    });
+    let savedUser = await this.userRepository.save(user);
+
+    // Generate key pairs
+    await this.userService.generateKeyPairs(savedUser.id);
+
+    // Create corresponding Actor entity
+    const actor = await this.actorSyncService.syncUserToActor(savedUser);
+
+    // Reload user with actor relation
+    savedUser = (await this.userRepository.findOne({
+      where: { id: savedUser.id },
+      relations: ['actor'],
+    })) as User;
+
+    // Create invitation codes
+    const invitations: Invitation[] = [];
+    for (let i = 0; i < 3; i++) {
+      const invitationCode = randomBytes(16).toString('base64url');
+      const invitation = this.invitationRepository.create({
+        code: invitationCode,
+        invitedBy: savedUser,
+        invitedById: savedUser.id,
+        maxUses: 5,
+        note: `Invitation ${i + 1} from ${username}`,
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days
+      });
+
+      const saved = await this.invitationRepository.save(invitation);
+      invitations.push(saved);
+    }
+
+    return {
+      user: savedUser,
+      actor,
+      invitations: invitations.map((inv) => ({
+        code: inv.code,
+        url: `${process.env.FRONTEND_URL || 'http://localhost:3001'}/auth/signup?invitation=${inv.code}`,
+        maxUses: inv.maxUses,
+        expiresAt: inv.expiresAt,
+      })),
+    };
+  }
+
+  // Toggle admin status
+  async toggleAdminStatus(userId: string, isAdmin: boolean) {
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    user.isAdmin = isAdmin;
+    await this.userRepository.save(user);
+
+    return user;
+  }
+
+  // Grant admin role to user by email
+  async grantAdminByEmail(email: string) {
+    const user = await this.userRepository.findOne({
+      where: { email },
+    });
+
+    if (!user) {
+      throw new NotFoundException(`User with email ${email} not found`);
+    }
+
+    user.isAdmin = true;
+    await this.userRepository.save(user);
+
+    return user;
+  }
+
+  // Request admin magic link
+  async requestAdminMagicLink(email: string): Promise<void> {
+    // Check if user exists
+    const user = await this.userRepository.findOne({
+      where: { email },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Check if user has admin privileges
+    if (!user.isAdmin) {
+      throw new UnauthorizedException('Admin privileges required');
+    }
+
+    // Use AuthService to generate magic link with admin URL
+    const adminUrl = process.env.ADMIN_URL || 'http://localhost:3004';
+    await this.authService.requestMagicLink(email, undefined, adminUrl);
+  }
+}

--- a/packages/backend/src/modules/auth/decorators/public.decorator.ts
+++ b/packages/backend/src/modules/auth/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/packages/backend/src/modules/auth/decorators/roles.decorator.ts
+++ b/packages/backend/src/modules/auth/decorators/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/packages/backend/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/packages/backend/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,5 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ExecutionContext } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+}

--- a/packages/backend/src/modules/auth/guards/roles.guard.ts
+++ b/packages/backend/src/modules/auth/guards/roles.guard.ts
@@ -1,0 +1,43 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    // Check if route is public
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+
+    if (!user) {
+      return false;
+    }
+
+    // Check if user has admin role
+    if (requiredRoles.includes('admin')) {
+      return user.isAdmin === true;
+    }
+
+    return true;
+  }
+}

--- a/packages/backend/src/scripts/grant-admin.ts
+++ b/packages/backend/src/scripts/grant-admin.ts
@@ -1,0 +1,37 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from '../app.module';
+import { AdminService } from '../modules/admin/admin.service';
+
+async function grantAdmin() {
+  const args = process.argv.slice(2);
+
+  if (args.length < 1) {
+    console.error('Usage: npm run grant-admin <email>');
+    console.error('Example: npm run grant-admin alice@example.com');
+    process.exit(1);
+  }
+
+  const [email] = args;
+
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const adminService = app.get(AdminService);
+
+  try {
+    const user = await adminService.grantAdminByEmail(email);
+
+    console.log('\n=== Admin Role Granted ===');
+    console.log(`Username: ${user.username}`);
+    console.log(`Email: ${user.email}`);
+    console.log(`Display Name: ${user.displayName}`);
+    console.log(`Is Admin: ${user.isAdmin}`);
+    console.log('==========================\n');
+  } catch (error) {
+    console.error('Error granting admin role:', error.message);
+    process.exit(1);
+  } finally {
+    await app.close();
+  }
+}
+
+// Run the script
+grantAdmin();


### PR DESCRIPTION

<img width="1425" height="719" alt="스크린샷 2025-10-08 23 44 14" src="https://github.com/user-attachments/assets/358bb4cc-d9e5-47d4-88ae-9d8ca0cd9995" />

# Summary

- **Add admin service's URL to CORS allowlist**
- **Add isAdmin field to User entity**
- **Add `grant-admin` CLI command for backend application**
- **Implement role-based and public access guards for authentication module**
- **Add AdminModule with user management APIs and middleware updates**
- **Expand auth service to handle callback URLs and include admin flag in JWT**
- **Implement pages for @cosmoslide/admin (list up user/actor)**
